### PR TITLE
Allow dynamically created types in Array, etc.

### DIFF
--- a/lib/bindata/sanitize.rb
+++ b/lib/bindata/sanitize.rb
@@ -9,8 +9,7 @@ module BinData
     def initialize(obj_type, obj_params, endian)
       endian = endian.endian if endian.respond_to? :endian
       obj_params ||= {}
-
-      if BinData::Base === obj_type
+      if BinData::Base === obj_type or obj_type.is_a?(Class)
         obj_class = obj_type
       else
         obj_class = RegisteredClasses.lookup(obj_type, endian)


### PR DESCRIPTION
Sometimes, it is nice to be able to create BinData records dynamically. This works wonderfully, except when passing the newly created types to BinData::Array and friends, because they do not show up in the type registry. This allows us to pass a reference to the class in instead of the type reference, bypassing the label lookup (note that the first check might be redundant, I am not too familiar with ===).  

E.g. BinData::Array.new( :type=> @factory.sym, :initial_length => 10).read(@data).snapshot when you have a factory for bindata types...
