### PR TITLE
Fix tests for JRuby.

### DIFF
--- a/test/io_test.rb
+++ b/test/io_test.rb
@@ -5,28 +5,14 @@ require File.expand_path(File.join(File.dirname(__FILE__), "common"))
 describe BinData::IO, "reading from non seekable stream" do
   before do
     @rd, @wr = IO::pipe
-    if fork
-      # parent
-      @wr.close
-      @io = BinData::IO.new(@rd)
-    else
-      # child
-      begin
-        @rd.close
-        @wr.write "a" * 5000
-        @wr.write "b" * 5000
-        @wr.close
-      rescue Exception
-        # ignore it
-      ensure
-        exit!
-      end
-    end
+    @io = BinData::IO.new(@rd)
+    @wr.write "a" * 5000
+    @wr.write "b" * 5000
+    @wr.close
   end
 
   after do
     @rd.close
-    Process.wait
   end
 
   it "always has an offset of 0" do

--- a/test/lazy_test.rb
+++ b/test/lazy_test.rb
@@ -73,16 +73,16 @@ end
 
 describe BinData::LazyEvaluator, "with one parent" do
   subject {
-    parent_methods = {:m1 => 'Pm1', :com => 'PmC', :mm => 3}
-    parent_params  = {:p1 => 'Pp1', :com => 'PpC'}
+    parent_methods = {:m1 => 'Pm1', :com1 => 'PmC', :mm => 3}
+    parent_params  = {:p1 => 'Pp1', :com1 => 'PpC'}
     parent_obj = MockBinDataObject.new(parent_methods, parent_params)
 
     def parent_obj.echo(a1, a2)
       [a1, a2]
     end
 
-    methods = {:m1 => 'm1', :com => 'mC'}
-    params  = {:p1 => 'p1', :com => 'pC'}
+    methods = {:m1 => 'm1', :com1 => 'mC'}
+    params  = {:p1 => 'p1', :com1 => 'pC'}
     MockBinDataObject.new(methods, params, parent_obj)
   }
 
@@ -119,7 +119,7 @@ describe BinData::LazyEvaluator, "with one parent" do
   end
 
   it "resolves parameters in preference to methods in the parent" do
-    lazy_eval(lambda { com }).must_equal 'PpC'
+    lazy_eval(lambda { com1 }).must_equal 'PpC'
   end
 
   it "has a parent" do
@@ -133,8 +133,8 @@ end
 
 describe BinData::LazyEvaluator, "with nested parents" do
   subject {
-    pparent_methods = {:m1 => 'PPm1', :m2 => 'PPm2', :com => 'PPmC'}
-    pparent_params  = {:p1 => 'PPp1', :p2 => 'PPp2', :com => 'PPpC'}
+    pparent_methods = {:m1 => 'PPm1', :m2 => 'PPm2', :com1 => 'PPmC'}
+    pparent_params  = {:p1 => 'PPp1', :p2 => 'PPp2', :com1 => 'PPpC'}
     pparent_obj = MockBinDataObject.new(pparent_methods, pparent_params)
 
     def pparent_obj.echo(arg)
@@ -145,16 +145,16 @@ describe BinData::LazyEvaluator, "with nested parents" do
       ["PP2", arg]
     end
 
-    parent_methods = {:m1 => 'Pm1', :com => 'PmC', :sym1 => :m2, :sym2 => lambda { m2 }}
-    parent_params  = {:p1 => 'Pp1', :com => 'PpC'}
+    parent_methods = {:m1 => 'Pm1', :com1 => 'PmC', :sym1 => :m2, :sym2 => lambda { m2 }}
+    parent_params  = {:p1 => 'Pp1', :com1 => 'PpC'}
     parent_obj = MockBinDataObject.new(parent_methods, parent_params, pparent_obj)
 
     def parent_obj.echo(arg)
       ["P", arg]
     end
 
-    methods = {:m1 => 'm1', :com => 'mC'}
-    params  = {:p1 => 'p1', :com => 'pC'}
+    methods = {:m1 => 'm1', :com1 => 'mC'}
+    params  = {:p1 => 'p1', :com1 => 'pC'}
     MockBinDataObject.new(methods, params, parent_obj)
   }
 
@@ -198,7 +198,7 @@ describe BinData::LazyEvaluator, "with nested parents" do
   end
 
   it "resolves parameters in preference to methods in the parent" do
-    lazy_eval(lambda { com }).must_equal 'PpC'
+    lazy_eval(lambda { com1 }).must_equal 'PpC'
   end
 
   it "resolves methods in the parent explicitly" do


### PR DESCRIPTION
This fix includes two changes:
- Do not use fork in io_test.rb

The tests dependent on fork were just as easily implemented in a
single process using the pipe directly.
- Use a key other than "com" in lazy_test.rb

JRuby defines a top-level method "com" for our Java integration,
so this test's use of a :com key broke when method_missing did not
fire and our method was called. Changed name to :com1.
