### PR TITLE
when onlyif is false, associated field shouldn't create instance methods

### DIFF
--- a/test/record_test.rb
+++ b/test/record_test.rb
@@ -550,9 +550,9 @@ describe BinData::Record, "with :onlyif" do
   it "identifies if fields are included" do
     obj.a?.must_equal true
     obj.b?.must_equal true
-    assert_raises NoMethodError { obj.c? }
-    assert_raises NoMethodError { obj.c }
-    assert_raises NoMethodError { obj.c = 8 }
+    assert_raises(NoMethodError) { obj.c? }
+    assert_raises(NoMethodError) { obj.c }
+    assert_raises(NoMethodError) { obj.c = 8 }
   end
 
   it "reads as lambdaed" do


### PR DESCRIPTION
When a field has an :onlyif parameter that resolves to false, the method shouldn't exist at all.

This test captures that expected behavior.  **It will also cause the current test suite to fail.**

According to your documentation on the wiki, "If the value of this parameter is false, then the field will be as if it didn't exist in the record." but while the method with an appended question mark results in false, the test as previously written did not seem to capture that intended behavior.

I can think of two reasons why the test should be more stringent.  Feel free to criticize these reasons.

1.) When one sets two optional fields with the same name, but only one should pass through due to onlyif expected bahavior, a nasty error is thrown telling the user/developer that two fields have the same name even though one of them ought to have been "as if it didn't exist in the record".

```
string :id, length: 4, onlyif: :short_length
string :id, length: 6, onlyif: :long_length
```

This is a contrived example, but it gets the point across.

2.) when an array is optional, the field will still set aside resources as if the field did exist.  This is wasteful and inefficient, especially for larger arrays.

```
array :data, type: :uint8, initial_length: 1000000, onlyif: :data_is_there
```

In this example, even if the data_is_there method returns false, the #data method will still exist and return an array with 1000000 zeros in it.

**If this is not how you want onlyif to behave, feel free to delete this issue and pull request.**

Thanks,
- Dominic
