### PR TITLE
Array: Handle the case of reading empty array with :read_until always true

### DIFF
--- a/lib/bindata/array.rb
+++ b/lib/bindata/array.rb
@@ -44,6 +44,8 @@ module BinData
   #                            this parameter.  If the value of this parameter
   #                            is the symbol :eof, then the array will read
   #                            as much data from the stream as possible.
+  #                            The condition is evaluated before each element
+  #                            being read allowing to read empty arrays.
   #
   # Each data object in an array has the variable +index+ made available
   # to any lambda evaluated as a parameter of that data object.
@@ -297,11 +299,12 @@ module BinData
   module ReadUntilPlugin
     def do_read(io)
       loop do
-        element = append_new_element
-        element.do_read(io)
         variables = { :index => self.length - 1, :element => self.last,
                       :array => self }
         break if eval_parameter(:read_until, variables)
+
+        element = append_new_element
+        element.do_read(io)
       end
     end
 

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -261,6 +261,7 @@ describe BinData::Array, "with :read_until" do
     end
   end
 
+
   describe "containing +array+ and +index+" do
     it "reads until the sentinel is reached" do
       read_until = lambda { index >= 2 and array[index - 2] == 5 }
@@ -268,6 +269,16 @@ describe BinData::Array, "with :read_until" do
 
       obj.read "\x01\x02\x03\x04\x05\x06\x07\x08"
       obj.must_equal [1, 2, 3, 4, 5, 6, 7]
+    end
+  end
+
+  describe "containing empty +array+" do
+    it "reads until the sentinel is reached, but the sentinel is always true" do
+      read_until = lambda { true }
+      obj = BinData::Array.new(:type => :int8, :read_until => read_until)
+
+      obj.read "\x01"
+      obj.must_equal []
     end
   end
 


### PR DESCRIPTION
In some case, we can have to read variable size array with a size that
can be 0.