### PR TITLE
enables to get the hexadecimal string representation of the object

### DIFF
--- a/lib/bindata/base.rb
+++ b/lib/bindata/base.rb
@@ -182,6 +182,11 @@ module BinData
       io.read
     end
 
+    # Returns the hexadecimal string representation of this data object.
+    def to_hex
+      self.to_binary_s.unpack('H*')[0]
+    end
+
     # Return a human readable representation of this data object.
     def inspect
       snapshot.inspect


### PR DESCRIPTION
Quite simple but often useful in some cases (optional: add .upcase)