### PR TITLE
detect that Windows TCP sockets are unseekable

### DIFF
--- a/lib/bindata/io.rb
+++ b/lib/bindata/io.rb
@@ -29,7 +29,7 @@ module BinData
 
       def seekable?
         @raw_io.pos
-      rescue NoMethodError, Errno::ESPIPE, Errno::EPIPE
+      rescue NoMethodError, Errno::ESPIPE, Errno::EPIPE, Errno::EINVAL
         nil
       end
 


### PR DESCRIPTION
Doing a read in bindata on a Windows TCP socket returns an exception in the seekable? method. It appears that checking for the .pos method returns the EINVAL errno. This adds the additional rescue to the check.

See https://github.com/rapid7/ruby_smb/pull/138#issuecomment-402248674 and thanks to @chrisdlf for finding the root cause.