### PR TITLE
`to_binary_s` should always return ASCII-8BIT encoded strings

### DIFF
--- a/lib/bindata/base.rb
+++ b/lib/bindata/base.rb
@@ -172,8 +172,7 @@ module BinData
     def to_binary_s(&block)
       io = BinData::IO.create_string_io
       write(io, &block)
-      io.rewind
-      io.read
+      io.string
     end
 
     # Returns the hexadecimal string representation of this data object.

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -52,6 +52,25 @@ describe BinData::Buffer, "subclassed with a single type" do
     obj.to_binary_s.must_equal_binary "\000\003\000\000\000"
   end
 
+  it "returns binary encoded data" do
+    obj = IntBuffer.new(3)
+    obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
+  end
+
+  it "returns binary encoded data despite Encoding.default_internal" do
+    w, $-w = $-w, false
+    before_enc = Encoding.default_internal
+
+    begin
+      Encoding.default_internal = Encoding::UTF_8
+      obj = IntBuffer.new(3)
+      obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
+    ensure
+      Encoding.default_internal = before_enc
+      $-w = w
+    end
+  end
+
   it "has total num_bytes" do
     obj = IntBuffer.new
     assert obj.clear?


### PR DESCRIPTION
StringIO in Ruby <= 2.6.X didn't respect `Encoding.default_internal`, so
calling `read` on the StringIO wouldn't tag the string with the same
encoding.  Ruby 2.7 fixes this bug.  The problem is that `to_binary_s`
is returning a binary string and should always return an ASCII-8BIT
encoded string.

This patch changes the method to always return the ASCII-8BIT string
regardless of the value of `Encoding.default_internal`.

Here is the behavior of StringIO on Ruby 2.6:

```
$ ruby -v -rstringio -e'Encoding.default_internal = Encoding::UTF_8; io = StringIO.new("foo".force_encoding("ASCII-8BIT")); io.rewind; p io.read.encoding'
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin19]
-e:1: warning: setting Encoding.default_internal
 #<Encoding:ASCII-8BIT>
```

Here it is on 2.7:

```
$ ruby -v -rstringio -e'Encoding.default_internal = Encoding::UTF_8; io = StringIO.new("foo".force_encoding("ASCII-8BIT")); io.rewind; p io.read.encoding'
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
-e:1: warning: setting Encoding.default_internal
  #<Encoding:UTF-8>
```

We can see 2.7 respects `default_internal`, but unfortunately that means
that `to_binary_s` would return the wrong encoding.