### PR TITLE
Set binmode on the StringIO

### DIFF
--- a/lib/bindata/io.rb
+++ b/lib/bindata/io.rb
@@ -213,7 +213,9 @@ module BinData
 
     # Creates a StringIO around +str+.
     def self.create_string_io(str = "")
-      StringIO.new(str.dup.force_encoding(Encoding::BINARY))
+      s = StringIO.new(str.dup.force_encoding(Encoding::BINARY))
+      s.binmode
+      s
     end
 
     # Create a new IO Read wrapper around +io+.  +io+ must provide #read,

--- a/test/buffer_test.rb
+++ b/test/buffer_test.rb
@@ -52,25 +52,6 @@ describe BinData::Buffer, "subclassed with a single type" do
     obj.to_binary_s.must_equal_binary "\000\003\000\000\000"
   end
 
-  it "returns binary encoded data" do
-    obj = IntBuffer.new(3)
-    obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
-  end
-
-  it "returns binary encoded data despite Encoding.default_internal" do
-    w, $-w = $-w, false
-    before_enc = Encoding.default_internal
-
-    begin
-      Encoding.default_internal = Encoding::UTF_8
-      obj = IntBuffer.new(3)
-      obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
-    ensure
-      Encoding.default_internal = before_enc
-      $-w = w
-    end
-  end
-
   it "has total num_bytes" do
     obj = IntBuffer.new
     assert obj.clear?
@@ -173,3 +154,36 @@ describe BinData::Buffer, "nested buffers" do
   end
 end
 
+describe BinData::Buffer, "encoding" do
+  class EncodingTestBufferRecord < BinData::Record
+    endian :big
+    default_parameter length: 5
+
+    uint16 :num
+    string :str, length: 10
+  end
+
+  it "returns binary encoded data" do
+    obj = EncodingTestBufferRecord.new(num: 3)
+    obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
+  end
+
+  it "returns binary encoded data with utf-8 string" do
+    obj = EncodingTestBufferRecord.new(num: 3, str: "日本語")
+    obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
+  end
+
+  it "returns binary encoded data despite Encoding.default_internal" do
+    w, $-w = $-w, false
+    before_enc = Encoding.default_internal
+
+    begin
+      Encoding.default_internal = Encoding::UTF_8
+      obj = EncodingTestBufferRecord.new(num: 3, str: "日本語")
+      obj.to_binary_s.encoding.must_equal Encoding::ASCII_8BIT
+    ensure
+      Encoding.default_internal = before_enc
+      $-w = w
+    end
+  end
+end


### PR DESCRIPTION
We always want `to_binary_s` to return an ASCII-8BIT string.  Setting
`binmode` ensures that if a UTF-8 string is written to the underlying
string buffer, the string buffer won't get converted to UTF-8 as well.