### PR TITLE
Fix primitive array mutations caused by #to_binary_s and #do_num_bytes

### DIFF
--- a/lib/bindata/array.rb
+++ b/lib/bindata/array.rb
@@ -82,6 +82,7 @@ module BinData
     def assign(array)
       raise ArgumentError, "can't set a nil value for #{debug_name}" if array.nil?
 
+      array = array.to_ary
       @element_list = []
       concat(array)
     end

--- a/test/primitive_test.rb
+++ b/test/primitive_test.rb
@@ -208,3 +208,30 @@ describe BinData::Primitive, "with mutating #get and #set" do
     obj.to_binary_s.must_equal_binary "\062\000"
   end
 end
+
+describe BinData::Primitive, "when describing an array" do
+  class ArrayPrimitive < BinData::Primitive
+    endian :little
+    array :elements, type: :uint8
+
+    def get
+      self.elements
+    end
+
+    def set(v)
+      self.elements = v
+    end
+  end
+
+  it "#do_num_bytes does not change the value" do
+    obj = ArrayPrimitive.new([1, 2])
+    obj.do_num_bytes.must_equal 2
+    obj.to_ary.must_equal [1, 2]
+  end
+
+  it "#to_binary_s does not change the value" do
+    obj = ArrayPrimitive.new([1, 2])
+    obj.to_binary_s.must_equal_binary "\001\002"
+    obj.to_ary.must_equal [1, 2]
+  end
+end


### PR DESCRIPTION
This fixes a bug introduced in 4c3be0f97a878c6c4e241f001297d6691456ed20 which causes `BinData::Primitive` objects that use `BinData::Array` to be altered when using `#to_binary_s` and `#do_num_bytes`. I added unit tests to demonstrate the issues. The source of the problem appears to be cases where in `BinData::Array#assign` the element list that is cleared is the same object as the `array` parameter. This leads to unintentionally clearing the object.

Issue before the patch:
```
2.6.5 :002 > class MyArray < BinData::Primitive
2.6.5 :003 >   endian :little
2.6.5 :004 >   array :elements, type: :uint8
2.6.5 :005 >   def get
2.6.5 :006 >     self.elements
2.6.5 :007 >   end
2.6.5 :008 >   def set(v)
2.6.5 :009 >     self.elements = v
2.6.5 :010 >   end
2.6.5 :011 > end
 => :set 
2.6.5 :012 > my_array = MyArray.new([1, 2])
2.6.5 :013 > my_array.to_binary_s
 => "" 
2.6.5 :014 > my_array
 => [] 
2.6.5 :015 >
```

Issue after the patch:
```
2.6.5 :002 > class MyArray < BinData::Primitive
2.6.5 :003 >   endian :little
2.6.5 :004 >   array :elements, type: :uint8
2.6.5 :005 >   def get
2.6.5 :006 >     self.elements
2.6.5 :007 >   end
2.6.5 :008 >   def set(v)
2.6.5 :009 >     self.elements = v
2.6.5 :010 >   end
2.6.5 :011 > end
 => :set 
2.6.5 :012 > my_array = MyArray.new([1, 2])
2.6.5 :013 > my_array.to_binary_s
 => "\x01\x02" 
2.6.5 :014 > my_array
 => [1, 2] 
2.6.5 :015 >
```