### PR TITLE
Fix Stringz max_length trimming

### DIFF
--- a/lib/bindata/stringz.rb
+++ b/lib/bindata/stringz.rb
@@ -80,7 +80,7 @@ module BinData
     def trim_to!(str, max_length = nil)
       if max_length
         max_length = 1 if max_length < 1
-        str.slice!(max_length)
+        str.slice!(max_length..-1)
         if str.length == max_length && str[-1, 1] != "\0"
           str[-1, 1] = "\0"
         end

--- a/test/stringz_test.rb
+++ b/test/stringz_test.rb
@@ -106,12 +106,12 @@ describe BinData::Stringz, "with max_length" do
   end
 
   it "trims values greater than max_length" do
-    obj.assign("abcde")
+    obj.assign("abcdefg")
     obj.must_equal "abcd"
   end
 
   it "writes values greater than max_length" do
-    obj.assign("abcde")
+    obj.assign("abcdefg")
     obj.to_binary_s.must_equal_binary "abcd\0"
   end
 


### PR DESCRIPTION
This fixes a bug that causes a wrong trimming of `Stringz` strings when the size is greater than `:max_length`. I updated some unit tests to demonstrate the issue. I tracked down the issue to `Stringz#trim_to!`, where the raw string is sliced according to `:max_length` parameter value.
```ruby
    def trim_to!(str, max_length = nil)
      if max_length
        max_length = 1 if max_length < 1
        str.slice!(max_length)
        if str.length == max_length && str[-1, 1] != "\0"
          str[-1, 1] = "\0"
        end
      end
    end
```
This results in removing the character at the `:max_length` position instead of removing all the remaining characters:
```
[1] pry(main)> str = "ABCDEFG"
=> "ABCDEFG"
[2] pry(main)> str.slice!(3)
=> "D"
[3] pry(main)> str
=> "ABCEFG"
```

Issue before this fix:
```
[1] pry(main)> require 'bindata'
=> true
[2] pry(main)> obj = BinData::Stringz.new(max_length: 5)
=> ""
[3] pry(main)> obj.assign("mybigstring")
=> "mybigstring"
[4] pry(main)> obj.snapshot
=> "mybigtring"
[5] pry(main)> obj.to_binary_s
=> "mybigtring\x00"
```

Now with this fix:
```
[1] pry(main)> require 'bindata'
=> true
[2] pry(main)> obj = BinData::Stringz.new(max_length: 5)
=> ""
[3] pry(main)> obj.assign("mybigstring")
=> "mybigstring"
[4] pry(main)> obj.snapshot
=> "mybi"
[5] pry(main)> obj.to_binary_s
=> "mybi\x00"
```