### PR TITLE
Evaluate read_until before adding an array element

### DIFF
--- a/lib/bindata/array.rb
+++ b/lib/bindata/array.rb
@@ -300,11 +300,11 @@ module BinData
   # Logic for the :read_until parameter
   module ReadUntilPlugin
     def do_read(io)
-      loop do
+      variables = { index: -1, element: nil, array: self }
+      until eval_parameter(:read_until, variables)
         element = append_new_element
         element.do_read(io)
         variables = { index: self.length - 1, element: self.last, array: self }
-        break if eval_parameter(:read_until, variables)
       end
     end
   end

--- a/lib/bindata/array.rb
+++ b/lib/bindata/array.rb
@@ -300,7 +300,7 @@ module BinData
   # Logic for the :read_until parameter
   module ReadUntilPlugin
     def do_read(io)
-      variables = { index: -1, element: nil, array: self }
+      variables = { index: self.length - 1, element: self.last, array: self }
       until eval_parameter(:read_until, variables)
         element = append_new_element
         element.do_read(io)


### PR DESCRIPTION
These proposed changes fix an `EOFError` that would be raised when an array reads an empty string that should be prevented by the `read_until` function. This is useful when the parent structure has some field indicating that the array has data, however it is terminated by a sentinel value. Due to a flag indicating the presence of array elements and a senintel being used for termination, it's not easy to use the `initial_length`. Without these changes, there would be an exception raised when no data should be read because there are no entries in the array.

Before these changes, this exception could be reproduced with:
```
[1] pry(main)> require 'bindata'; obj = BinData::Array.new(:type => :int8, read_until: -> { true }); obj.read("")
EOFError: End of file reached
from /home/smcintyre/Repositories/bindata/lib/bindata/io.rb:316:in `read'
[2] pry(main)> 
```