### PR TITLE
Use UTF-8 encoding for examples

### DIFF
--- a/examples/NBT.txt
+++ b/examples/NBT.txt
@@ -107,7 +107,7 @@ You should end up with this:
 	   TAG_Short("shortTest"): 32767
 	   TAG_Long("longTest"): 9223372036854775807
 	   TAG_Float("floatTest"): 0.49823147
-	   TAG_String("stringTest"): HELLO WORLD THIS IS A TEST STRING ÅÄÖ!
+	   TAG_String("stringTest"): HELLO WORLD THIS IS A TEST STRING Ã…Ã„Ã–!
 	   TAG_Int("intTest"): 2147483647
 	   TAG_Compound("nested compound test"): 2 entries
 	   {


### PR DESCRIPTION
The file `examples/NBT.txt` is currently using the latin1 encoding to store the accented character. This contribution proposes to convert this file to unicode (UTF-8).