### PR TITLE
various: fix miscellaneous typos

### DIFF
--- a/examples/list.rb
+++ b/examples/list.rb
@@ -35,7 +35,7 @@ require 'bindata'
 #       end
 #     end
 #
-# Notice how we get stuck on attemping to write a declaration for
+# Notice how we get stuck on attempting to write a declaration for
 # the contents of the list.  We can't determine if the list item is
 # an atom or list because we haven't read it yet.  It appears that
 # we can't proceed.

--- a/lib/bindata/io.rb
+++ b/lib/bindata/io.rb
@@ -374,12 +374,12 @@ module BinData
     #
     # To create a new transform layer, subclass +Transform+.
     # Override the public methods +#read+ and +#write+ at a minimum.
-    # Additionally the hook, +#before_transform+, +#after_read_transfrom+
+    # Additionally the hook, +#before_transform+, +#after_read_transform+
     # and +#after_write_transform+ are available as well.
     #
     # IMPORTANT!  If your transform changes the size of the underlying
     # data stream (e.g. compression), then call
-    # +::transfrom_changes_stream_length!+ in your subclass.
+    # +::transform_changes_stream_length!+ in your subclass.
     class Transform
       class << self
         # Indicates that this transform changes the length of the

--- a/lib/bindata/skip.rb
+++ b/lib/bindata/skip.rb
@@ -36,7 +36,7 @@ module BinData
   #
   # <tt>:length</tt>::        The number of bytes to skip.
   # <tt>:to_abs_offset</tt>:: Skips to the given absolute offset.
-  # <tt>:until_valid</tt>::   Skips untils a given byte pattern is matched.
+  # <tt>:until_valid</tt>::   Skips until a given byte pattern is matched.
   #                           This parameter contains a type that will raise
   #                           a BinData::ValidityError unless an acceptable byte
   #                           sequence is found.  The type is represented by a

--- a/test/choice_test.rb
+++ b/test/choice_test.rb
@@ -243,7 +243,7 @@ describe BinData::Choice, "subclassed with default parameters" do
     _(obj.num_bytes).must_equal 2
   end
 
-  it "overides default parameter" do
+  it "overrides default parameter" do
     obj = DerivedChoice.new(selection: 'b')
     _(obj.num_bytes).must_equal 4
   end

--- a/test/io_test.rb
+++ b/test/io_test.rb
@@ -362,7 +362,7 @@ describe BinData::IO::Write, "writing bits in little endian" do
 end
 
 describe BinData::IO::Read, "with changing endian" do
-  it "does not mix different endianess when reading" do
+  it "does not mix different endianness when reading" do
     b1 = 0b0110_1010
     b2 = 0b1110_0010
     str = [b1, b2].pack("CC")
@@ -374,7 +374,7 @@ describe BinData::IO::Read, "with changing endian" do
 end
 
 describe BinData::IO::Write, "with changing endian" do
-  it "does not mix different endianess when writing" do
+  it "does not mix different endianness when writing" do
     io = BitWriterHelper.new
     io.writebits(0b110, 3, :big)
     io.writebits(0b010, 3, :little)

--- a/test/section_test.rb
+++ b/test/section_test.rb
@@ -27,7 +27,7 @@ describe BinData::Section do
       end
 
       obj = BrotliRecord.new
-      data = "highly compressable" * 100
+      data = "highly compressible" * 100
       obj.s.str = data
       _(obj.len).must_be :<, (data.length / 10)
 
@@ -52,7 +52,7 @@ describe BinData::Section do
       end
 
       obj = LZ4Record.new
-      data = "highly compressable" * 100
+      data = "highly compressible" * 100
       obj.s.str = data
       _(obj.len).must_be :<, (data.length / 10)
 
@@ -75,7 +75,7 @@ describe BinData::Section do
     end
 
     obj = ZlibRecord.new
-    data = "highly compressable" * 100
+    data = "highly compressible" * 100
     obj.s.str = data
     _(obj.len).must_be :<, (data.length / 10)
 
@@ -99,7 +99,7 @@ describe BinData::Section do
       end
 
       obj = ZstdRecord.new
-      data = "highly compressable" * 100
+      data = "highly compressible" * 100
       obj.s.str = data
       _(obj.len).must_be :<, (data.length / 10)
 


### PR DESCRIPTION
This PR aims to fix various minor typos across the codebase. I noticed some of these when doing the same review on our Homebrew/brew repo, since we use bindata.