### PR TITLE
Refactor: Only lookup without prefix once

### DIFF
--- a/lib/bindata/registry.rb
+++ b/lib/bindata/registry.rb
@@ -63,20 +63,18 @@ module BinData
     def normalize_name(name, hints)
       name = underscore_name(name)
 
-      if !registered?(name)
-        search_prefix = [""] + Array(hints[:search_prefix])
-        search_prefix.each do |prefix|
-          nwp = name_with_prefix(name, prefix)
-          if registered?(nwp)
-            name = nwp
-            break
-          end
+      search_prefix = [""] + Array(hints[:search_prefix])
+      search_prefix.each do |prefix|
+        nwp = name_with_prefix(name, prefix)
+        if registered?(nwp)
+          name = nwp
+          break
+        end
 
-          nwe = name_with_endian(nwp, hints[:endian])
-          if registered?(nwe)
-            name = nwe
-            break
-          end
+        nwe = name_with_endian(nwp, hints[:endian])
+        if registered?(nwe)
+          name = nwe
+          break
         end
       end
 


### PR DESCRIPTION
Just a tiny cleanup opportunity I came across while researching for / prototyping a solution for multiple registries (#157).

The loop over `search_prefix` already checks the variant with the empty string prefix, so the first call to `registered?` is essentially a duplicate. This way, we can reduce the nesting a bit. 😊 