### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/bindata

### DIFF
--- a/bindata.gemspec
+++ b/bindata.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
     format.  It is an easier ( and more readable ) alternative to
     ruby's #pack and #unpack methods.
   END
+  s.metadata['changelog_uri'] = s.homepage + '/blob/master/ChangeLog.rdoc'
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/bindata which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/