### PR TITLE
Remove test files from gem contents

### DIFF
--- a/bindata.gemspec
+++ b/bindata.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rdoc_options << '--main' << 'NEWS.rdoc'
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |file|
-      file.start_with?(*%w[.git INSTALL])
+      file.start_with?(*%w[.git INSTALL test/])
     end
   end
   s.license = 'BSD-2-Clause'


### PR DESCRIPTION
This reduces the gem size from 85k to 55k, and would follow the pattern of many gems (including [rails](https://github.com/rails/rails/pull/22272))