### PR TITLE
Explicitly forward keyword args in `BasePrimitive#method_missing`

### DIFF
--- a/lib/bindata/base_primitive.rb
+++ b/lib/bindata/base_primitive.rb
@@ -93,17 +93,33 @@ module BinData
       child.respond_to?(symbol, include_all) || super
     end
 
-    def method_missing(symbol, *args, **kwargs, &block) # :nodoc:
-      child = snapshot
-      if child.respond_to?(symbol)
-        self.class.class_eval <<-END, __FILE__, __LINE__ + 1
-          def #{symbol}(*args, **kwargs, &block)        # def clamp(*args, &block)
-            snapshot.#{symbol}(*args, **kwargs, &block) #   snapshot.clamp(*args, &block)
-          end                                           # end
-        END
-        child.__send__(symbol, *args, **kwargs, &block)
-      else
-        super
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
+      def method_missing(symbol, *args, &block) # :nodoc:
+        child = snapshot
+        if child.respond_to?(symbol)
+          self.class.class_eval <<-END, __FILE__, __LINE__ + 1
+            def #{symbol}(*args, &block)                  # def clamp(*args, &block)
+              snapshot.#{symbol}(*args, &block)           #   snapshot.clamp(*args, &block)
+            end                                           # end
+          END
+          child.__send__(symbol, *args, &block)
+        else
+          super
+        end
+      end
+    else
+      def method_missing(symbol, *args, **kwargs, &block) # :nodoc:
+        child = snapshot
+        if child.respond_to?(symbol)
+          self.class.class_eval <<-END, __FILE__, __LINE__ + 1
+            def #{symbol}(*args, **kwargs, &block)        # def clamp(*args, **kwargs, &block)
+              snapshot.#{symbol}(*args, **kwargs, &block) #   snapshot.clamp(*args, **kwargs, &block)
+            end                                           # end
+          END
+          child.__send__(symbol, *args, **kwargs, &block)
+        else
+          super
+        end
       end
     end
 

--- a/lib/bindata/base_primitive.rb
+++ b/lib/bindata/base_primitive.rb
@@ -93,15 +93,15 @@ module BinData
       child.respond_to?(symbol, include_all) || super
     end
 
-    def method_missing(symbol, *args, &block) # :nodoc:
+    def method_missing(symbol, *args, **kwargs, &block) # :nodoc:
       child = snapshot
       if child.respond_to?(symbol)
         self.class.class_eval <<-END, __FILE__, __LINE__ + 1
-          def #{symbol}(*args, &block)         # def clamp(*args, &block)
-            snapshot.#{symbol}(*args, &block)  #   snapshot.clamp(*args, &block)
-          end                                  # end
+          def #{symbol}(*args, **kwargs, &block)        # def clamp(*args, &block)
+            snapshot.#{symbol}(*args, **kwargs, &block) #   snapshot.clamp(*args, &block)
+          end                                           # end
         END
-        child.__send__(symbol, *args, &block)
+        child.__send__(symbol, *args, **kwargs, &block)
       else
         super
       end

--- a/test/string_test.rb
+++ b/test/string_test.rb
@@ -259,6 +259,14 @@ describe BinData::String, "with :pad_front" do
   end
 end
 
+describe BinData::String, "delegated methods" do
+  let(:obj) { BinData::String.new("testing\x92") }
+
+  it "successfully delegates calls with keyword args" do
+    _(obj.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')).must_equal "testing?"
+  end
+end
+
 describe BinData::String, "with Ruby 1.9 encodings" do
   class UTF8String < BinData::String
     def snapshot


### PR DESCRIPTION
In ruby 3.0+, keyword args are treated as strictly distinct from options hashes, and need to be explicitly forwarded when delegating calls, otherwise you get errors like:

```
> BinData::String.new("hi").encode("utf-8", undef: :replace, replace: '?')
BinData::String::delegated methods#test_0001_correctly delegates String#encode:
TypeError: no implicit conversion of Hash into String
    lib/bindata/base_primitive.rb:104:in 'String#encode'
```

This PR patches the `BasePrimitive` method_missing delegation to take account of that.

For the time being I've only applied this at the `BasePrimitive` level, with a test on `BinData::String` (since this is where I encountered the issue), but there are numerous other `method_missing` delegators on concrete data types, which may also need attention, but I don't have a great understanding of this project so I didn't want to just blindly go editing. If anyone has some insight on whether this is a generally-safe change to make, I'd be happy to extend it.

Finally: ruby 2.5 is still in the CI matrix, but it doesn't support keywords. Is that still a supported ruby version in this gem?

Edited to add: I've pushed a second commit that's [passing on all rubies](https://github.com/urbanautomaton/bindata/actions/runs/29105681770); it's not pretty but it does at least illustrate what would be required in the other delegators to support the existing build matrix.